### PR TITLE
Upgrade file-type to 12.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -700,9 +700,9 @@
       }
     },
     "file-type": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.0.0.tgz",
-      "integrity": "sha512-lKSLYIUQpx+HkWbnBEbW+GEcK1gYLwvlFp8i91yjzKGZD36tmZJ2Yl0f65umHWN6XlUWu+Jr56a4sYP7M/qmnw=="
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.0.1.tgz",
+      "integrity": "sha512-YIs1E51cmqcmgF38ODjy0+M/l5DyfIIy3vngTOujQr/lXqkaSskfBniaZoZ1HVIpa5FTf5e7hCXS4TzxfNGMRQ=="
     },
     "find-root": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "standard": "^12.0.1"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "index.js"
   ],
   "dependencies": {
-    "file-type": "^10.0.0",
+    "file-type": "^12.0.0",
     "readable-stream": "^3.0.6"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -42,4 +42,18 @@ describe('stream-file-type', () => {
       .then(type => assert.deepStrictEqual(type, { ext: 'woff2', mime: 'font/woff2' }))
       .then(() => assert.deepStrictEqual(emitted, { ext: 'woff2', mime: 'font/woff2' }))
   })
+
+  it('should handle files with undefined file type', () => {
+    const input = fs.createReadStream('fixture/test.invalidf')
+    const detector = new FileType()
+
+    input.pipe(detector).resume()
+
+    let emitted
+    detector.on('file-type', fileType => { emitted = fileType })
+
+    return detector.fileTypePromise()
+      .then(type => assert.deepStrictEqual(type, undefined))
+      .then(() => assert.deepStrictEqual(emitted, undefined))
+  })
 })


### PR DESCRIPTION
Hi @LinusU,
https://github.com/sindresorhus/file-type extended their list of supported file types.

There have been two breaking changes since v10:
- Return `undefined` instead of `null` when there's no match https://github.com/sindresorhus/file-type/releases/tag/v11.0.0
- Require Node >=8 (https://github.com/sindresorhus/file-type/releases/tag/v12.0.0)

So I guess this should be released as a breaking change in this module as well.