### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,13 @@
 import { Duplex, Readable } from 'stream'
 
-declare class FileType extends Duplex {
+declare namespace FileType {
+  interface FileTypeResult {
+    ext: string
+    mime: string
+  }
+}
+
+export default class FileType extends Duplex {
   fileTypePromise(): Promise<FileType.FileTypeResult | null>
 
   addListener(event: 'close', listener: () => void): this
@@ -39,12 +46,3 @@ declare class FileType extends Duplex {
   once(event: 'unpipe', listener: (src: Readable) => void): this
   once(event: string | symbol, listener: (...args: any[]) => void): this;
 }
-
-declare namespace FileType {
-  interface FileTypeResult {
-    ext: string
-    mime: string
-  }
-}
-
-export = FileType

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-const fileType = require('file-type')
-const { PassThrough, Transform } = require('stream')
+import { PassThrough, Transform } from 'node:stream'
+import fileType from 'file-type'
 
 const kResult = Symbol('result')
 const kStream = Symbol('stream')
 
-class FileType extends Transform {
+export default class FileType extends Transform {
   constructor () {
     super()
 
@@ -44,5 +44,3 @@ class FileType extends Transform {
     }
   }
 }
-
-module.exports = FileType

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.5.0",
   "license": "MIT",
   "repository": "LinusU/stream-file-type",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
     "test": "standard && mocha"
   },
@@ -11,14 +13,14 @@
     "index.js"
   ],
   "dependencies": {
-    "file-type": "^14.1.4"
+    "file-type": "^16.0.0"
   },
   "devDependencies": {
-    "hasha": "^5.2.0",
-    "mocha": "^7.1.1",
-    "standard": "^14.3.3"
+    "hasha": "^5.2.2",
+    "mocha": "^9.0.2",
+    "standard": "^16.0.3"
   },
   "engines": {
-    "node": ">=10.13"
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@ Get the [file type](https://github.com/sindresorhus/file-type) by inspecting a s
 ## Usage
 
 ```js
-const fs = require('fs')
-const FileType = require('stream-file-type')
+import fs from 'node:fs'
+import FileType from 'stream-file-type'
 
 const input = fs.createReadStream('cat.jpg')
 const detector = new FileType()

--- a/test.js
+++ b/test.js
@@ -1,13 +1,13 @@
 /* eslint-env mocha */
 
-const fs = require('fs')
-const assert = require('assert')
-const hasha = require('hasha')
+import assert from 'node:assert'
+import fs from 'node:fs'
+import hasha from 'hasha'
 
-const FileType = require('./')
+import FileType from './index.js'
 
 describe('stream-file-type', () => {
-  it('should detect the file type of a stream', () => {
+  it('should detect the file type of a stream', async () => {
     const input = fs.createReadStream('fixture/fixture.mid')
     const detector = new FileType()
 
@@ -16,20 +16,22 @@ describe('stream-file-type', () => {
     let emitted
     detector.on('file-type', fileType => { emitted = fileType })
 
-    return detector.fileTypePromise()
-      .then(type => assert.deepStrictEqual(type, { ext: 'mid', mime: 'audio/midi' }))
-      .then(() => assert.deepStrictEqual(emitted, { ext: 'mid', mime: 'audio/midi' }))
+    const type = await detector.fileTypePromise()
+
+    assert.deepStrictEqual(type, { ext: 'mid', mime: 'audio/midi' })
+    assert.deepStrictEqual(emitted, { ext: 'mid', mime: 'audio/midi' })
   })
 
-  it('should pass the input as-is', () => {
+  it('should pass the input as-is', async () => {
     const input = fs.createReadStream('fixture/fixture.mid')
     const detector = new FileType()
 
-    return hasha.fromStream(input.pipe(detector), { algorithm: 'sha1' })
-      .then(hash => assert.strictEqual(hash, '02cd79ed1d5f07eef736f79122aa89e6fe4f0d4b'))
+    const hash = await hasha.fromStream(input.pipe(detector), { algorithm: 'sha1' })
+
+    assert.strictEqual(hash, '02cd79ed1d5f07eef736f79122aa89e6fe4f0d4b')
   })
 
-  it('should handle files larger than 4100 bytes', () => {
+  it('should handle files larger than 4100 bytes', async () => {
     const input = fs.createReadStream('fixture/fixture-otto.woff2')
     const detector = new FileType()
 
@@ -38,12 +40,13 @@ describe('stream-file-type', () => {
     let emitted
     detector.on('file-type', fileType => { emitted = fileType })
 
-    return detector.fileTypePromise()
-      .then(type => assert.deepStrictEqual(type, { ext: 'woff2', mime: 'font/woff2' }))
-      .then(() => assert.deepStrictEqual(emitted, { ext: 'woff2', mime: 'font/woff2' }))
+    const type = await detector.fileTypePromise()
+
+    assert.deepStrictEqual(type, { ext: 'woff2', mime: 'font/woff2' })
+    assert.deepStrictEqual(emitted, { ext: 'woff2', mime: 'font/woff2' })
   })
 
-  it('should handle files with unknown file type', () => {
+  it('should handle files with unknown file type', async () => {
     const input = fs.createReadStream('fixture/test.invalidf')
     const detector = new FileType()
 
@@ -52,8 +55,9 @@ describe('stream-file-type', () => {
     let emitted
     detector.on('file-type', fileType => { emitted = fileType })
 
-    return detector.fileTypePromise()
-      .then(type => assert.strictEqual(type, null))
-      .then(() => assert.strictEqual(emitted, null))
+    const type = await detector.fileTypePromise()
+
+    assert.strictEqual(type, null)
+    assert.strictEqual(emitted, null)
   })
 })


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`