### PR TITLE
Fix stream stalling on small files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,9 +39,7 @@ export default class FileType extends Transform {
   _flush (cb) {
     if (this[kStream] != null) {
       this[kStream].end()
-      cb(null)
-    } else {
-      cb(null)
     }
+    cb(null)
   }
 }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ export default class FileType extends Transform {
 
   _flush (cb) {
     if (this[kStream] != null) {
-      this[kStream].end(() => cb(null))
+      this[kStream].end()
+      cb(null)
     } else {
       cb(null)
     }


### PR DESCRIPTION
Node: v17.0.0
OS: Windows 11

The end callback is never called on some smaller files causing the pipeline to stall. This seemed to fix it.