### PR TITLE
fix: stream `end` operation failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ export default class FileType extends Transform {
 
   _flush (cb) {
     if (this[kStream] != null) {
-      this[kStream].end(() => cb(null))
+      this[kStream].on('close', () => cb(null))
+      this[kStream].destroy()
     } else {
       cb(null)
     }


### PR DESCRIPTION
In NestJS, when the user uploads some weird file, the `end` operation of the stream will fail and the stream needs to be forced off by the `destroy` operation